### PR TITLE
Remove ENV Assignment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,6 @@ jobs:
           name: code-coverage-report
           path: htmlcov
 
-      # Set the environment variable for the Git tag to pass along to the build
-      # process in the next step
-      - name: Set Environment
-        if: startsWith(github.ref, 'refs/tags')
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $TAG_VERSION
-
       # Build the Sphinx documentation into a PDF for easier distribution
       - name: Build Documentation
         run: |


### PR DESCRIPTION
- Removes tagging logic until it tracks commit versions and replaces the `_version.py` file